### PR TITLE
Post integration cleanup

### DIFF
--- a/.github/actions/define-snyk-arguments/action.yml
+++ b/.github/actions/define-snyk-arguments/action.yml
@@ -34,4 +34,4 @@ runs:
           SNYK_ARGS+=(--target-reference=${{ inputs.snyk_target_reference }})
         fi
         echo snyk_args="${SNYK_ARGS[@]}" >> $GITHUB_OUTPUT
-        echo "Snyk arguments: '${snyk_args}'"
+        echo "Snyk arguments: '${SNYK_ARGS[@]}'"

--- a/.github/workflows/snyk-vulnerability-report.yml
+++ b/.github/workflows/snyk-vulnerability-report.yml
@@ -33,20 +33,15 @@ on:
 
 permissions:
   contents: read
+  security-events: write
 
 jobs:
   snyk-vulnerability-report:
     runs-on: ubuntu-latest
 
-    permissions:
-      security-events: write
-
     env:
       GITHUB_TOKEN: ${{ secrets.gh_token }}
       SNYK_TOKEN: ${{ secrets.snyk_token }}
-      SNYK_ORG: ${{ inputs.snyk_organisation }}
-      SNYK_TEST_EXCLUDE: ${{ inputs.snyk_test_exclude }}
-      SNYK_TARGET_REFERENCE: ${{ inputs.snyk_target_reference }}
 
     steps:
       - uses: actions/checkout@v4
@@ -55,26 +50,20 @@ jobs:
         with:
           java-version: ${{ inputs.java_version }}
           distribution: ${{ inputs.java_distribution }}
-      - uses: ministryofjustice/laa-ccms-common-workflows/.github/actions/define-snyk-arguments@story/ccmspui-35-common-workflows
+      - uses: ministryofjustice/laa-ccms-common-workflows/.github/actions/define-snyk-arguments@v1
         id: define-snyk-arguments
         with:
           snyk_organisation: ${{ inputs.snyk_organisation }}
           snyk_test_exclude: ${{ inputs.snyk_test_exclude }}
           snyk_target_reference: ${{ inputs.snyk_target_reference }}
+      - uses: snyk/actions/setup@0.4.0
       - name: Generate Snyk report and upload to org dashboard
-        uses: snyk/actions/gradle@0.4.0
-        continue-on-error: true
-        with:
-          command: monitor
-          args: --all-projects ${{ steps.define-snyk-arguments.outputs.snyk_args }}
+        run: snyk monitor --all-projects ${{ steps.define-snyk-arguments.outputs.snyk_args }}
       - name: Generate sarif Snyk report
-        if: ${{ inputs.sarif_report == 'true' }}
-        uses: snyk/actions/gradle@0.4.0
-        continue-on-error: true
-        with:
-          args: --all-projects ${{ steps.define-snyk-arguments.outputs.snyk_args }} --sarif-file-output=snyk-report.sarif
+        if: ${{ inputs.github_code_scanning_report == 'true' }}
+        run: snyk test --all-projects ${{ steps.define-snyk-arguments.outputs.snyk_args }} --sarif-file-output=snyk-report.sarif
       - name: Fix undefined values
-        if: ${{ inputs.sarif_report == 'true' }}
+        if: ${{ inputs.github_code_scanning_report == 'true' }}
         run: |
           cat snyk-report.sarif | jq '
               .runs[].tool[].rules[]
@@ -93,7 +82,7 @@ jobs:
                )
           ' > snyk-report-cleansed.sarif
       - name: Upload result to GitHub Code Scanning
-        if: ${{ inputs.sarif_report == 'true' }}
+        if: ${{ inputs.github_code_scanning_report == 'true' }}
         uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: snyk-report-cleansed.sarif

--- a/.github/workflows/snyk-vulnerability-scan.yml
+++ b/.github/workflows/snyk-vulnerability-scan.yml
@@ -52,7 +52,7 @@ jobs:
           mkdir -p ~/.local/bin
           export PATH="$HOME/.local/bin/:$PATH"
           npm install -g snyk-delta
-      - uses: ministryofjustice/laa-ccms-common-workflows/.github/actions/define-snyk-arguments@story/ccmspui-35-common-workflows
+      - uses: ministryofjustice/laa-ccms-common-workflows/.github/actions/define-snyk-arguments@v1
         id: define-snyk-arguments
         with:
           snyk_organisation: ${{ inputs.snyk_organisation }}


### PR DESCRIPTION
Fixed some issues found after merging one of the dependent repositories:

- Snyk gradle action does not work with the setup-java action. Changed to use the snyk setup action with cli commands instead. See https://github.com/snyk/actions?tab=readme-ov-file#bring-your-own-development-environment.
- `sarif_report` parameter in the vulnerability report workflow was incorrectly named. Updated to`github_code_scanning_report`.
- Use release versions of actions
- Fixed a log message