### PR TITLE
Fix: vulnerability reporting

### DIFF
--- a/.github/workflows/snyk-vulnerability-report.yml
+++ b/.github/workflows/snyk-vulnerability-report.yml
@@ -61,7 +61,7 @@ jobs:
         run: snyk monitor --all-projects ${{ steps.define-snyk-arguments.outputs.snyk_args }}
       - name: Generate sarif Snyk report
         if: ${{ inputs.github_code_scanning_report == 'true' }}
-        run: snyk test --all-projects ${{ steps.define-snyk-arguments.outputs.snyk_args }} --sarif-file-output=snyk-report.sarif
+        run: snyk test --all-projects ${{ steps.define-snyk-arguments.outputs.snyk_args }} --sarif-file-output=snyk-report.sarif || true
       - name: Fix undefined values
         if: ${{ inputs.github_code_scanning_report == 'true' }}
         run: |


### PR DESCRIPTION
Previously, `continue-on-error` was set to `true` when generating the snyk sarif test report. Now that the snyk action cannot be used due to incompatibility with the setup-java action, this functionality needs to be replicated with `|| true` to avoid 'failed' exit codes when vulnerabilities are found. At this stage we just need a report of vulnerabilities to be generated.