### PR TITLE
Fix: Set SNYK_API env var

### DIFF
--- a/.github/workflows/snyk-vulnerability-scan.yml
+++ b/.github/workflows/snyk-vulnerability-scan.yml
@@ -37,6 +37,7 @@ jobs:
     env:
       GITHUB_TOKEN: ${{ secrets.gh_token }}
       SNYK_TOKEN: ${{ secrets.snyk_token }}
+      SNYK_API: "https://api.snyk.io"
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
The latest version of snyk-delta uses a new version of the Snyk API: https://docs.snyk.io/snyk-api/v1-api. New configuration around setting the URL for this API has introduced a bug.
https://github.com/snyk-tech-services/snyk-delta/compare/v1.12.3...v1.12.6

![Screenshot 2025-04-14 at 18 10 46](https://github.com/user-attachments/assets/7fd08249-d7a9-45d8-8500-bf3dab3b911a)

After using the latest version, running scans would fail with:

![Screenshot 2025-04-14 at 18 12 58](https://github.com/user-attachments/assets/d0c9d692-13e0-4a3c-9f90-d24f0b222d1c)


This is a workaround to ensure the API URL is set as expected.