### PR TITLE
Add Snyk policy path parameter

### DIFF
--- a/.github/workflows/ecr-publish-image.yml
+++ b/.github/workflows/ecr-publish-image.yml
@@ -29,6 +29,10 @@ on:
         required: false
         type: string
         default: 'upgradable'
+      image_scan_policy_path:
+        required: false
+        type: string
+        default: '.snyk'
       publish:
         required: false
         type: string
@@ -105,7 +109,7 @@ jobs:
         with:
           registries: ${{ secrets.ecr_registry }}
         id: login-another-ecr
- 
+
       - name: Configure certificate binding
         if: ${{ env.ROOT_CERTIFICATE != '' }}
         run: |
@@ -162,7 +166,8 @@ jobs:
             --org=legal-aid-agency \
             --severity-threshold=${{ inputs.image_scan_severity }} \
             --fail-on=${{ inputs.image_scan_fail_on }} \
-            --sarif-file-output=snyk-report.sarif
+            --sarif-file-output=snyk-report.sarif \
+            --policy-path=${{ inputs.image_scan_policy_path }}
 
       - name: Fix undefined values in sarif report
         if: ${{ inputs.image_scan == 'true' }}

--- a/README.md
+++ b/README.md
@@ -139,17 +139,18 @@ jobs:
 
 #### Inputs
 
-| Input                 | Description                                                                                                                                                             | Required | Default      |
-|-----------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------|--------------|
-| `java_version`        | The Java JDK version to run build commands with.                                                                                                                        | false    | `25`         |
-| `java_distribution`   | The Java JDK distribution.                                                                                                                                              | false    | `temurin`    |
-| `image_version`       | The image version to be published.                                                                                                                                      | true     |              |
-| `jar_subproject`      | The gradle subproject to run the `bootBuildImage` task in.                                                                                                              | false    |              |
-| `image_scan`          | Whether to scan the built image (via Snyk).                                                                                                                             | false    | `true`       |
-| `image_scan_severity` | The minumum severity level to flag in the image scan report. Any vulnerabilities identified at this level or above will fail the pipeline.                              | false    | `medium`     |
-| `image_scan_fail_on`  | The types of vulnerabiltiies that will fail the pipeline. See [snyk container test](https://docs.snyk.io/developer-tools/snyk-cli/commands/container-test) CLI command. | false    | `upgradable` |
-| `publish`             | Whether to publish the image. Disable for scanning only.                                                                                                                | false    | `true`       |
-| `tag_with_latest`                | Whether to publish the image with the `latest` tag also.       | false    | `false`                              |
+| Input                    | Description                                                                                                                                                             | Required | Default      |
+|--------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------|--------------|
+| `java_version`           | The Java JDK version to run build commands with.                                                                                                                        | false    | `25`         |
+| `java_distribution`      | The Java JDK distribution.                                                                                                                                              | false    | `temurin`    |
+| `image_version`          | The image version to be published.                                                                                                                                      | true     |              |
+| `jar_subproject`         | The gradle subproject to run the `bootBuildImage` task in.                                                                                                              | false    |              |
+| `image_scan`             | Whether to scan the built image (via Snyk).                                                                                                                             | false    | `true`       |
+| `image_scan_severity`    | The minumum severity level to flag in the image scan report. Any vulnerabilities identified at this level or above will fail the pipeline.                              | false    | `medium`     |
+| `image_scan_fail_on`     | The types of vulnerabiltiies that will fail the pipeline. See [snyk container test](https://docs.snyk.io/developer-tools/snyk-cli/commands/container-test) CLI command. | false    | `upgradable` |
+| `image_scan_policy_path` | The path to your [`.snyk` policy file](https://docs.snyk.io/manage-risk/policies/the-.snyk-file).                                                                       | false    | `.snyk`      |
+| `publish`                | Whether to publish the image. Disable for scanning only.                                                                                                                | false    | `true`       |
+| `tag_with_latest`        | Whether to publish the image with the `latest` tag also.                                                                                                                | false    | `false`      |
 
 #### Secrets
 


### PR DESCRIPTION
Adds the `image_scan_policy_path` parameter to the publish / scan image workflow. This also ensures Snyk policy files in the root directory are used by default.