### PR TITLE
Allow the use of snyk Oauth credentials

### DIFF
--- a/.github/workflows/ecr-publish-image.yml
+++ b/.github/workflows/ecr-publish-image.yml
@@ -192,7 +192,8 @@ jobs:
         id: snyk
         continue-on-error: true
         env:
-          SNYK_TOKEN: ${{ steps.auth.outputs.token || env.SNYK_TOKEN }}
+          SNYK_OAUTH_TOKEN: ${{ steps.auth.outputs.token  }}
+          SNYK_TOKEN: ${{ env.SNYK_TOKEN }}
         run: |
           snyk container test ${{ steps.build-image.outputs.image_name }} \
             --org=legal-aid-agency \

--- a/.github/workflows/ecr-publish-image.yml
+++ b/.github/workflows/ecr-publish-image.yml
@@ -96,18 +96,16 @@ jobs:
           java-version: ${{ inputs.java_version }}
           distribution: ${{ inputs.java_distribution }}
 
-      # Validate secrets: require either SNYK_TOKEN or both SNYK_CLIENT_ID and SNYK_CLIENT_SECRET
-      - name: Validate Snyk secrets
+      # Validate secrets and set flag if Snyk Oauth token is required
+      - name: Validate Snyk secrets and set flag
+        if: ${{ inputs.image_scan == 'true' }}
+        id: validate-and-set-snyk-oauth-token-required
         run: |
           if [ -z "${{ secrets.snyk_token }}" ] && { [ -z "${{ secrets.snyk_client_id }}" ] || [ -z "${{ secrets.snyk_client_secret }}" ]; }; then
             echo "Error: You must provide either SNYK_TOKEN or both SNYK_CLIENT_ID and SNYK_CLIENT_SECRET as secrets."
+            echo "required=false" >> $GITHUB_OUTPUT
             exit 1
           fi
-
-      # Set flag to determine if we need to obtain a short-lived Snyk token
-      - name: Set SNYK_TOKEN_REQUIRED flag
-        id: set-snyk-token-required
-        run: |
           if [ -z "${{ secrets.snyk_token }}" ] && [ -n "${{ secrets.snyk_client_id }}" ] && [ -n "${{ secrets.snyk_client_secret }}" ]; then
             echo "required=true" >> $GITHUB_OUTPUT
           else
@@ -117,19 +115,11 @@ jobs:
       # Obtain short-lived Snyk token if required
       - name: Obtain Short-lived Snyk token
         id: auth
-        if: steps.set-snyk-token-required.outputs.required == 'true'
-        uses: ministryofjustice/laa-reusable-github-actions/.github/actions/snyk-auth@feat/snyk-token-output
+        if: ${{ inputs.image_scan == 'true' && steps.validate-and-set-snyk-oauth-token-required.outputs.required == 'true' }}
+        uses: ministryofjustice/laa-reusable-github-actions/.github/actions/snyk-auth@6db001458db30ae747d9eb8eb25707ce52b359bc # v??? no versioning in the action currently
         with:
           client_id: ${{ secrets.snyk_client_id }}
           client_secret: ${{ secrets.snyk_client_secret }}
-
-      # Set SNYK_TOKEN from auth step output if needed
-      - name: Set SNYK_TOKEN from auth output
-        if: steps.set-snyk-token-required.outputs.required == 'true'
-        run: |
-          if [ -z "$SNYK_TOKEN" ] && [ -n "${{ steps.auth.outputs.token }}" ]; then
-            echo "SNYK_TOKEN=${{ steps.auth.outputs.token }}" >> $GITHUB_ENV
-          fi
 
       - name: Configure aws credentials
         if: ${{ inputs.publish == 'true' }}
@@ -202,7 +192,7 @@ jobs:
         id: snyk
         continue-on-error: true
         env:
-          SNYK_TOKEN: ${{ env.SNYK_TOKEN }}
+          SNYK_TOKEN: ${{ steps.auth.outputs.token || env.SNYK_TOKEN }}
         run: |
           snyk container test ${{ steps.build-image.outputs.image_name }} \
             --org=legal-aid-agency \

--- a/.github/workflows/ecr-publish-image.yml
+++ b/.github/workflows/ecr-publish-image.yml
@@ -259,3 +259,25 @@ jobs:
             echo "Image published to ECR with version: \`${{ inputs.image_version }}\`" >> $GITHUB_STEP_SUMMARY
             echo "Published image version: ${{ inputs.image_version }}"
           fi
+
+      - name: Warn about deprecated SNYK_TOKEN usage
+        if: ${{ env.SNYK_TOKEN != '' }}
+        run: |
+          echo "::warning title=Deprecated SNYK_TOKEN::A SNYK_TOKEN was used to authenticate with Snyk. Snyk recommends OAuth 2.0 service accounts (SNYK_CLIENT_ID + SNYK_CLIENT_SECRET). SNYK_TOKEN support will be removed in a future release."
+
+      - name: Add migration guidance to job summary
+        if: ${{ env.SNYK_TOKEN != '' }}
+        run: |
+          {
+            echo "## ⚠️ Deprecated: SNYK_TOKEN"
+            echo ""
+            echo "Your workflow is using \`SNYK_TOKEN\` to authenticate with Snyk."
+            echo ""
+            echo "### Why migrate?"
+            echo "Snyk recommends OAuth 2.0 service accounts for CI/CD pipelines."
+            echo ""
+            echo "### How to migrate"
+            echo "Replace \`SNYK_TOKEN\` with \`SNYK_CLIENT_ID\` and \`SNYK_CLIENT_SECRET\`"
+            echo ""
+            echo "> 🚨 **\`SNYK_TOKEN\` support will be removed in a future release.**"
+          } >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/ecr-publish-image.yml
+++ b/.github/workflows/ecr-publish-image.yml
@@ -261,12 +261,12 @@ jobs:
           fi
 
       - name: Warn about deprecated SNYK_TOKEN usage
-        if: ${{ env.SNYK_TOKEN != '' }}
+        if: ${{ inputs.image_scan == 'true' && env.SNYK_TOKEN != '' }}
         run: |
           echo "::warning title=Deprecated SNYK_TOKEN::A SNYK_TOKEN was used to authenticate with Snyk. Snyk recommends OAuth 2.0 service accounts (SNYK_CLIENT_ID + SNYK_CLIENT_SECRET). SNYK_TOKEN support will be removed in a future release."
 
       - name: Add migration guidance to job summary
-        if: ${{ env.SNYK_TOKEN != '' }}
+        if: ${{ inputs.image_scan == 'true' && env.SNYK_TOKEN != '' }}
         run: |
           {
             echo "## ⚠️ Deprecated: SNYK_TOKEN"

--- a/.github/workflows/ecr-publish-image.yml
+++ b/.github/workflows/ecr-publish-image.yml
@@ -6,11 +6,11 @@ on:
       java_version:
         required: false
         type: string
-        default: 25
+        default: '25'
       java_distribution:
         required: false
         type: string
-        default: temurin
+        default: 'temurin'
       image_version:
         required: true
         type: string
@@ -20,7 +20,7 @@ on:
       image_scan:
         required: false
         type: string
-        default: true
+        default: 'true'
       image_scan_severity:
         required: false
         type: string
@@ -36,7 +36,7 @@ on:
       publish:
         required: false
         type: string
-        default: true
+        default: 'true'
       tag_with_latest:
         required: false
         type: boolean
@@ -53,7 +53,11 @@ on:
       ecr_registry:
         required: false
       snyk_token:
-        required: true
+        required: false
+      snyk_client_id:
+        required: false
+      snyk_client_secret:
+        required: false
       root_certificate:
         required: false
       binding_directory:
@@ -78,6 +82,7 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.gh_token }}
       ECR_REGISTRY: ${{ secrets.ecr_registry }}
       ROOT_CERTIFICATE: ${{ secrets.root_certificate }}
+      # SNYK_TOKEN will be set below if available, otherwise set by auth step
       SNYK_TOKEN: ${{ secrets.snyk_token }}
 
     outputs:
@@ -90,6 +95,41 @@ jobs:
         with:
           java-version: ${{ inputs.java_version }}
           distribution: ${{ inputs.java_distribution }}
+
+      # Validate secrets: require either SNYK_TOKEN or both SNYK_CLIENT_ID and SNYK_CLIENT_SECRET
+      - name: Validate Snyk secrets
+        run: |
+          if [ -z "${{ secrets.snyk_token }}" ] && { [ -z "${{ secrets.snyk_client_id }}" ] || [ -z "${{ secrets.snyk_client_secret }}" ]; }; then
+            echo "Error: You must provide either SNYK_TOKEN or both SNYK_CLIENT_ID and SNYK_CLIENT_SECRET as secrets."
+            exit 1
+          fi
+
+      # Set flag to determine if we need to obtain a short-lived Snyk token
+      - name: Set SNYK_TOKEN_REQUIRED flag
+        id: set-snyk-token-required
+        run: |
+          if [ -z "${{ secrets.snyk_token }}" ] && [ -n "${{ secrets.snyk_client_id }}" ] && [ -n "${{ secrets.snyk_client_secret }}" ]; then
+            echo "required=true" >> $GITHUB_OUTPUT
+          else
+            echo "required=false" >> $GITHUB_OUTPUT
+          fi
+
+      # Obtain short-lived Snyk token if required
+      - name: Obtain Short-lived Snyk token
+        id: auth
+        if: steps.set-snyk-token-required.outputs.required == 'true'
+        uses: ministryofjustice/laa-reusable-github-actions/.github/actions/snyk-auth@feat/snyk-token-output
+        with:
+          client_id: ${{ secrets.snyk_client_id }}
+          client_secret: ${{ secrets.snyk_client_secret }}
+
+      # Set SNYK_TOKEN from auth step output if needed
+      - name: Set SNYK_TOKEN from auth output
+        if: steps.set-snyk-token-required.outputs.required == 'true'
+        run: |
+          if [ -z "$SNYK_TOKEN" ] && [ -n "${{ steps.auth.outputs.token }}" ]; then
+            echo "SNYK_TOKEN=${{ steps.auth.outputs.token }}" >> $GITHUB_ENV
+          fi
 
       - name: Configure aws credentials
         if: ${{ inputs.publish == 'true' }}
@@ -161,6 +201,8 @@ jobs:
         if: ${{ inputs.image_scan == 'true' }}
         id: snyk
         continue-on-error: true
+        env:
+          SNYK_TOKEN: ${{ env.SNYK_TOKEN }}
         run: |
           snyk container test ${{ steps.build-image.outputs.image_name }} \
             --org=legal-aid-agency \

--- a/.github/workflows/ecr-publish-image.yml
+++ b/.github/workflows/ecr-publish-image.yml
@@ -116,7 +116,7 @@ jobs:
       - name: Obtain Short-lived Snyk token
         id: auth
         if: ${{ inputs.image_scan == 'true' && steps.validate-and-set-snyk-oauth-token-required.outputs.required == 'true' }}
-        uses: ministryofjustice/laa-reusable-github-actions/.github/actions/snyk-auth@6db001458db30ae747d9eb8eb25707ce52b359bc # v??? no versioning in the action currently
+        uses: ministryofjustice/laa-reusable-github-actions/.github/actions/snyk-auth@6db001458db30ae747d9eb8eb25707ce52b359bc # v??? no versioning on the action currently
         with:
           client_id: ${{ secrets.snyk_client_id }}
           client_secret: ${{ secrets.snyk_client_secret }}

--- a/README.md
+++ b/README.md
@@ -161,7 +161,9 @@ jobs:
 | `ecr_repository`     | The name of the ECR repository to publish to.                                                                                     | true     |         |
 | `ecr_role_to_assume` | The AWS role to assume to connect to ECR.                                                                                         | true     |         |
 | `ecr_registry`       | The ECR registry to publish to, if in a different account to the role.                                                            | false    |         |
-| `snyk_token`         | The API token for Snyk. This should be from an LAA service account. Required when `image_scan=true`.                              | true     |         |
+| `snyk_token`         | The API token for Snyk. This should be from an LAA service account. Required when `image_scan=true`.                              | false    |         |
+| `snyk_client_id`     | The API client id for Snyk. Required when `image_scan=true` and `snyk_token` not set.                                             | false    |         |
+| `snyk_client_secret` | The API client secret for Snyk. Required when `image_scan=true` and `snyk_token` not set.                                         | false    |         |
 | `root_certificate`   | The root certificate to embed into the image. This will be added to the JVM Truststore.                                           | false    |         |
 | `binding_directory`  | The directory used for binding the root certificate. See [Paketo Bindings](https://paketo.io/docs/howto/configuration/#bindings). | false    |         |
 


### PR DESCRIPTION
We have been requested to migrate our repositories away from using the Snyk access token and instead adopt OAuth-based authentication. This change requires providing the Snyk client ID and client secret, which will be used to request a short‑lived access token. The generated token will be used in place of the existing snyk_token. These changes are intended to be fully backward compatible.

Changes:
- Fixed type conflicts in the inputs
- Made snyk_token not required
- Added step to check if !snyk_token then you must provide snyk credentials
- Added step to determine if we should use snyk credentials to fetch he snyk short-lived access token
- Added step to get use credentials if defined
- Added step to set the env SNYK_TOKEN to result of getting the snyk short-lived access token