### PR TITLE
[DSTEW-1552] - Add ability to use PAT token on build but GH Token on tag update.

### DIFF
--- a/.github/workflows/gradle-build-and-publish.yml
+++ b/.github/workflows/gradle-build-and-publish.yml
@@ -83,6 +83,8 @@ on:
     secrets:
       gh_token:
         required: true
+      gh_pat_token:
+        required: false
       aws_region:
         required: false
       github_app_id:
@@ -120,7 +122,8 @@ jobs:
     name: ${{ inputs.create_tag == 'true' && 'Create tag' || (inputs.publish_package == 'Build and publish package' && 'Scan image') || 'Build pipeline' }}
 
     env:
-      GITHUB_TOKEN: ${{ secrets.gh_token }}
+      GITHUB_TOKEN: ${{ secrets.gh_pat_token || secrets.gh_token }} # Prefer personal access token for authentication to avoid potential issues with GitHub App token permissions, but fall back to GH_TOKEN if PAT is not provided
+      GH_TOKEN: ${{ secrets.gh_token }} # Some actions expect GH_TOKEN specifically, so we set both GITHUB_TOKEN and GH_TOKEN to ensure compatibility
       AWS_REGION: ${{ secrets.aws_region }}
       GITHUB_APP_ID: ${{ secrets.github_app_id }}
       GITHUB_APP_PRIVATE_KEY: ${{ secrets.github_app_private_key }}
@@ -196,7 +199,7 @@ jobs:
           git config --global user.name "${{ inputs.github_bot_username }}[bot]"
           ./gradlew release -Prelease.useAutomaticVersion=true
         env:
-          GITHUB_TOKEN: ${{ steps.get_workflow_token.outputs.token || env.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.get_workflow_token.outputs.token || env.GH_TOKEN || env.GITHUB_TOKEN }}
 
       - name: Capture published version
         id: capture_published_version

--- a/README.md
+++ b/README.md
@@ -376,7 +376,7 @@ jobs:
 | Input                  | Description                                                            | Required | 
 |------------------------|------------------------------------------------------------------------|----------|
 | `gh_token`             | The github token from the calling repository.                          | true     | 
-| `gh_pat_token`         | Private Access Token to enable access to packages fromt private repos. | false    |         
+| `gh_pat_token`         | Private Access Token to enable access to packages from private repos.  | false    |         
 | `pact_broker_url`      | The Pact Broker URL you want to test against or publish to.            | false    |         
 | `pact_broker_username` | The Pact Broker username. Required if you wish to publish results.     | false    |         
 | `pact_broker_password` | The Pact Broker password. Required if you wish to publish results.     | false    |         

--- a/README.md
+++ b/README.md
@@ -373,12 +373,13 @@ jobs:
 
 #### Secrets
 
-| Input                  | Description                                                        | Required | 
-|------------------------|--------------------------------------------------------------------|----------|
-| `gh_token`             | The github token from the calling repository.                      | true     |         
-| `pact_broker_url`      | The Pact Broker URL you want to test against or publish to.        | false    |         
-| `pact_broker_username` | The Pact Broker username. Required if you wish to publish results. | false    |         
-| `pact_broker_password` | The Pact Broker password. Required if you wish to publish results. | false    |         
+| Input                  | Description                                                            | Required | 
+|------------------------|------------------------------------------------------------------------|----------|
+| `gh_token`             | The github token from the calling repository.                          | true     | 
+| `gh_pat_token`         | Private Access Token to enable access to packages fromt private repos. | false    |         
+| `pact_broker_url`      | The Pact Broker URL you want to test against or publish to.            | false    |         
+| `pact_broker_username` | The Pact Broker username. Required if you wish to publish results.     | false    |         
+| `pact_broker_password` | The Pact Broker password. Required if you wish to publish results.     | false    |         
 
 ### PACT Provider Webhook
 


### PR DESCRIPTION
This change updates how the GitHub Action selects and uses authentication tokens, introducing a priority‑based token resolution strategy and context‑specific token selection for tagging.

### Token Resolution for Environment (GITHUB_TOKEN)
The environment token is now resolved in the following order:
1. **GitHub App token** - Derived from: App name, App private key / secret
2. **Personal Access Token (PAT)** -  If explicitly provided and no App token is configured.
3. **Default GITHUB_TOKEN** - Used as a required fallback when neither of the above are available.

This resolved token is then used for all build-related actions (checkout, dependency access, API calls, etc.).

### Token Resolution for Tag Creation
Because PATs cannot write directly to protected branches (e.g. main), tagging uses a stricter resolution:
1. GitHub App token
2. Default GITHUB_TOKEN