### PR TITLE
Fix: Image scanning for private/internal repositories

### DIFF
--- a/.github/workflows/ecr-publish-image.yml
+++ b/.github/workflows/ecr-publish-image.yml
@@ -75,6 +75,7 @@ on:
 
 permissions:
   contents: read
+  actions: read
   id-token: write
   security-events: write
 


### PR DESCRIPTION
`actions: read` is required for private/internal repositories to be able to upload Sarif files to GHAS. See https://docs.github.com/en/code-security/how-tos/find-and-fix-code-vulnerabilities/integrate-with-existing-tools/uploading-a-sarif-file-to-github

<img width="520" height="187" alt="Screenshot 2026-06-03 at 12 50 05" src="https://github.com/user-attachments/assets/1693f976-7c40-465e-b78f-f2f6abfe56c1" />


_**Note: This will be a breaking change for any existing pipelines using the ecr-publish-image step without the additional permission. DO NOT MERGE until there is a way forward on this.**_